### PR TITLE
Solved issue with BMP file filter. Can now open BMP files with filter.

### DIFF
--- a/ASPAS.py
+++ b/ASPAS.py
@@ -126,7 +126,7 @@ class Comparator(ttk.Frame):
         """Propmpts user to select a plate image file."""
         self.file = tk.filedialog.askopenfilename(initialdir = ".",
                                                   title = f"Select a file",
-                                                  filetypes = (("BMP files", "*.bmp*"), ("all files", "*.*")))
+                                                  filetypes = (("BMP files", "*.bmp"), ("all files", "*.*")))
         self.load_plate(self.file)
         self.scan_plate(self.file)
 


### PR DESCRIPTION
This small change allows me to open BMP files with the BMP filter in place. Fix for issue https://github.com/gnave/ASPAS/issues/2 for my machine (using macOS Monterey 12.6, python 3.8.3, tk 8.6.10). 

WARNING This issue/fix with tkinter may be platform-dependent (according to stackoverflow.com). I have only tested it with my machine. 

